### PR TITLE
Utilizar as relações do TypeOrm

### DIFF
--- a/src/constants/task/pagination.constant.ts
+++ b/src/constants/task/pagination.constant.ts
@@ -1,1 +1,1 @@
-export const NUMBER_OF_ENTRIES_PER_PAGE = 50;
+export const NUMBER_OF_ENTRIES_PER_PAGE = 3;

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -57,7 +57,7 @@ export class TaskController {
 
   @UseGuards(UserJwtAuthGuard)
   @HttpCode(HttpStatus.OK)
-  @Get()
+  @Get('paginated')
   async getTask(
     @Query() request: GetPaginatedTaskRequestDto,
   ): Promise<GetPaginatedTaskResponseDto> {

--- a/src/dto/index.ts
+++ b/src/dto/index.ts
@@ -14,7 +14,7 @@ export {
   GetPaginatedTaskRequestDto,
   GetPaginatedTaskResponseDto,
   GetPaginatedTimesDto,
-  TasksDto,
+  TaskDto,
 } from './task';
 export {
   CreateTaskTimeResponseDto,

--- a/src/dto/task/get-paginated/response.dto.ts
+++ b/src/dto/task/get-paginated/response.dto.ts
@@ -1,7 +1,7 @@
-import { TasksDto } from './task.dto';
+import { TaskDto } from './task.dto';
 
 export class GetPaginatedTaskResponseDto {
-  tasks: Array<TasksDto> = [];
+  tasks: Array<TaskDto> = [];
   page: number;
   isLastPage: boolean;
 }

--- a/src/dto/task/get-paginated/task.dto.ts
+++ b/src/dto/task/get-paginated/task.dto.ts
@@ -1,6 +1,6 @@
 import { GetPaginatedTimesDto } from './times.dto';
 
-export class TasksDto {
+export class TaskDto {
   id: number;
   title: string;
   description: string;

--- a/src/dto/task/index.ts
+++ b/src/dto/task/index.ts
@@ -6,4 +6,4 @@ export { UpdateTaskResponseDto } from './update/response.dto';
 export { GetPaginatedTaskRequestDto } from './get-paginated/request.dto';
 export { GetPaginatedTaskResponseDto } from './get-paginated/response.dto';
 export { GetPaginatedTimesDto } from './get-paginated/times.dto';
-export { TasksDto } from './get-paginated/task.dto';
+export { TaskDto } from './get-paginated/task.dto';

--- a/src/entities/task.entity.ts
+++ b/src/entities/task.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { TaskTime } from './taskTime.entity';
 
 @Entity()
@@ -24,6 +24,8 @@ export class Task {
   @Column({ name: 'updated_at' })
   updatedAt: string;
 
-  @OneToMany(() => TaskTime, (taskTime) => taskTime.task)
+  @OneToMany(() => TaskTime, (taskTime) => taskTime.task, {
+    cascade: ['remove'],
+  })
   times: TaskTime[];
 }

--- a/src/entities/task.entity.ts
+++ b/src/entities/task.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { TaskTime } from './taskTime.entity';
 
 @Entity()
 export class Task {
@@ -22,4 +23,7 @@ export class Task {
 
   @Column({ name: 'updated_at' })
   updatedAt: string;
+
+  @OneToMany(() => TaskTime, (taskTime) => taskTime.task)
+  times: TaskTime[];
 }

--- a/src/entities/taskTime.entity.ts
+++ b/src/entities/taskTime.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Task } from './task.entity';
 
 @Entity({ name: 'taskTime' })
 export class TaskTime {
@@ -22,4 +23,7 @@ export class TaskTime {
 
   @Column({ name: 'time_spent' })
   timeSpent: number;
+
+  @ManyToOne(() => Task, (task) => task.times)
+  task: Task;
 }

--- a/src/entities/taskTime.entity.ts
+++ b/src/entities/taskTime.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Task } from './task.entity';
 
 @Entity({ name: 'taskTime' })
@@ -18,12 +18,10 @@ export class TaskTime {
   @Column({ name: 'ended_at' })
   endedAt: string;
 
-  @Column({ name: 'id_task' })
-  taskId: number;
-
   @Column({ name: 'time_spent' })
   timeSpent: number;
 
-  @ManyToOne(() => Task, (task) => task.times)
+  @ManyToOne(() => Task, (task) => task.times, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'id_task' })
   task: Task;
 }

--- a/src/mappers/task-time/taskTime.mapper.test.ts
+++ b/src/mappers/task-time/taskTime.mapper.test.ts
@@ -42,7 +42,7 @@ describe('TaskTime mapper tests', () => {
     it('Converts task time to create task time response', () => {
       const taskTime: TaskTime = new TaskTime();
 
-      taskTime.taskId = 1;
+      // taskTime.taskId = 1;
       taskTime.timeSpent = 1234;
       taskTime.initiatedAt = '2024-02-26 10:30:18';
       taskTime.endedAt = '2024-02-26 12:00:00';

--- a/src/mappers/task-time/taskTime.mapper.test.ts
+++ b/src/mappers/task-time/taskTime.mapper.test.ts
@@ -22,24 +22,19 @@ describe('TaskTime mapper tests', () => {
 
   describe('fromCreateTaskTimeToTaskTime tests', () => {
     it('Converts a create task time request to task time', () => {
-      const request: CreateTaskTimeRequestDto = new CreateTaskTimeRequestDto();
-
-      request.taskId = 1;
-      request.initiatedAt = '2024-02-26 10:30:18';
-      request.endedAt = '2024-02-26 12:00:00';
-
-      const timeSpent: number = 1234;
-      const expected: TaskTime = new TaskTime();
-
-      expected.initiatedAt = request.initiatedAt;
-      expected.endedAt = request.endedAt;
-      expected.timeSpent = timeSpent;
-      expected.taskId = request.taskId;
-      expected.createdAt = dayjs(new Date()).format(DATE_TIME_FORMAT);
-
-      const result: TaskTime = taskTimeMapper.fromCreateTaskTimeToTaskTime(request, timeSpent);
-
-      expect(result).toEqual(expected);
+      // const request: CreateTaskTimeRequestDto = new CreateTaskTimeRequestDto();
+      // request.taskId = 1;
+      // request.initiatedAt = '2024-02-26 10:30:18';
+      // request.endedAt = '2024-02-26 12:00:00';
+      // const timeSpent: number = 1234;
+      // const expected: TaskTime = new TaskTime();
+      // expected.initiatedAt = request.initiatedAt;
+      // expected.endedAt = request.endedAt;
+      // expected.timeSpent = timeSpent;
+      // expected.taskId = request.taskId;
+      // expected.createdAt = dayjs(new Date()).format(DATE_TIME_FORMAT);
+      // const result: TaskTime = taskTimeMapper.fromCreateTaskTimeToTaskTime(request, timeSpent);
+      // expect(result).toEqual(expected);
     });
   });
 

--- a/src/mappers/task-time/taskTime.mapper.test.ts
+++ b/src/mappers/task-time/taskTime.mapper.test.ts
@@ -5,7 +5,7 @@ import {
   UpdateTaskTimeRequestDto,
   UpdateTaskTimeResponseDto,
 } from '@dtos';
-import { TaskTime } from '@entities';
+import { Task, TaskTime } from '@entities';
 import { DATE_TIME_FORMAT } from '@constants';
 import { TaskTimeMapper } from './taskTime.mapper';
 
@@ -22,19 +22,28 @@ describe('TaskTime mapper tests', () => {
 
   describe('fromCreateTaskTimeToTaskTime tests', () => {
     it('Converts a create task time request to task time', () => {
-      // const request: CreateTaskTimeRequestDto = new CreateTaskTimeRequestDto();
-      // request.taskId = 1;
-      // request.initiatedAt = '2024-02-26 10:30:18';
-      // request.endedAt = '2024-02-26 12:00:00';
-      // const timeSpent: number = 1234;
-      // const expected: TaskTime = new TaskTime();
-      // expected.initiatedAt = request.initiatedAt;
-      // expected.endedAt = request.endedAt;
-      // expected.timeSpent = timeSpent;
-      // expected.taskId = request.taskId;
-      // expected.createdAt = dayjs(new Date()).format(DATE_TIME_FORMAT);
-      // const result: TaskTime = taskTimeMapper.fromCreateTaskTimeToTaskTime(request, timeSpent);
-      // expect(result).toEqual(expected);
+      const request: CreateTaskTimeRequestDto = new CreateTaskTimeRequestDto();
+      request.taskId = 1;
+      request.initiatedAt = '2024-02-26 10:30:18';
+      request.endedAt = '2024-02-26 12:00:00';
+
+      const task: Task = new Task();
+      const timeSpent: number = 1234;
+      const expected: TaskTime = new TaskTime();
+
+      expected.initiatedAt = request.initiatedAt;
+      expected.endedAt = request.endedAt;
+      expected.timeSpent = timeSpent;
+      expected.createdAt = dayjs(new Date()).format(DATE_TIME_FORMAT);
+      expected.task = task;
+
+      const result: TaskTime = taskTimeMapper.fromCreateTaskTimeToTaskTime(
+        request,
+        timeSpent,
+        task,
+      );
+
+      expect(result).toEqual(expected);
     });
   });
 
@@ -42,7 +51,6 @@ describe('TaskTime mapper tests', () => {
     it('Converts task time to create task time response', () => {
       const taskTime: TaskTime = new TaskTime();
 
-      // taskTime.taskId = 1;
       taskTime.timeSpent = 1234;
       taskTime.initiatedAt = '2024-02-26 10:30:18';
       taskTime.endedAt = '2024-02-26 12:00:00';

--- a/src/mappers/task-time/taskTime.mapper.ts
+++ b/src/mappers/task-time/taskTime.mapper.ts
@@ -33,7 +33,6 @@ export class TaskTimeMapper {
     response.createdAt = taskTime.createdAt;
     response.endedAt = taskTime.endedAt;
     response.initiatedAt = taskTime.initiatedAt;
-    // response.taskId = taskTime.taskId;
     response.updatedAt = taskTime.updatedAt;
     response.timeSpent = taskTime.timeSpent;
 
@@ -60,7 +59,6 @@ export class TaskTimeMapper {
     response.createdAt = taskTime.createdAt;
     response.updatedAt = taskTime.updatedAt;
     response.id = taskTime.id;
-    // response.taskId = taskTime.taskId;
     response.timeSpent = taskTime.timeSpent;
     response.initiatedAt = taskTime.initiatedAt;
     response.endedAt = taskTime.endedAt;

--- a/src/mappers/task-time/taskTime.mapper.ts
+++ b/src/mappers/task-time/taskTime.mapper.ts
@@ -5,19 +5,23 @@ import {
   UpdateTaskTimeRequestDto,
   UpdateTaskTimeResponseDto,
 } from '@dtos';
-import { TaskTime } from '@entities';
+import { Task, TaskTime } from '@entities';
 import { Injectable } from '@nestjs/common';
 import dayjs from 'dayjs';
 
 @Injectable()
 export class TaskTimeMapper {
-  fromCreateTaskTimeToTaskTime(request: CreateTaskTimeRequestDto, timeSpent: number): TaskTime {
+  fromCreateTaskTimeToTaskTime(
+    request: CreateTaskTimeRequestDto,
+    timeSpent: number,
+    task: Task,
+  ): TaskTime {
     const taskTime: TaskTime = new TaskTime();
 
     taskTime.createdAt = dayjs(new Date()).format(DATE_TIME_FORMAT);
-    taskTime.taskId = request.taskId;
     taskTime.initiatedAt = dayjs(request.initiatedAt).format(DATE_TIME_FORMAT);
     taskTime.endedAt = dayjs(request.endedAt).format(DATE_TIME_FORMAT);
+    taskTime.task = task;
     taskTime.timeSpent = timeSpent;
 
     return taskTime;

--- a/src/mappers/task-time/taskTime.mapper.ts
+++ b/src/mappers/task-time/taskTime.mapper.ts
@@ -33,7 +33,7 @@ export class TaskTimeMapper {
     response.createdAt = taskTime.createdAt;
     response.endedAt = taskTime.endedAt;
     response.initiatedAt = taskTime.initiatedAt;
-    response.taskId = taskTime.taskId;
+    // response.taskId = taskTime.taskId;
     response.updatedAt = taskTime.updatedAt;
     response.timeSpent = taskTime.timeSpent;
 
@@ -60,7 +60,7 @@ export class TaskTimeMapper {
     response.createdAt = taskTime.createdAt;
     response.updatedAt = taskTime.updatedAt;
     response.id = taskTime.id;
-    response.taskId = taskTime.taskId;
+    // response.taskId = taskTime.taskId;
     response.timeSpent = taskTime.timeSpent;
     response.initiatedAt = taskTime.initiatedAt;
     response.endedAt = taskTime.endedAt;

--- a/src/mappers/task/task.mapper.test.ts
+++ b/src/mappers/task/task.mapper.test.ts
@@ -4,13 +4,13 @@ import {
   CreateTaskTimeResponseDto,
   GetPaginatedTaskResponseDto,
   GetPaginatedTimesDto,
-  TasksDto,
+  TaskDto,
   TimesDto,
   UpdateTaskRequestDto,
   UpdateTaskResponseDto,
 } from '@dtos';
 import { TaskMapper } from './task.mapper';
-import { Task } from '@entities';
+import { Task, TaskTime } from '@entities';
 import { TaskAndTime, UpdateTask } from '@interfaces';
 import dayjs from 'dayjs';
 import { DATE_TIME_FORMAT } from '@constants';
@@ -103,56 +103,32 @@ describe('TaskMapper tests', () => {
     });
   });
 
-  describe('formTasksAndTimesToPaginatedTasksResponse tests', () => {
-    interface tasksMock {
-      taskAndTime: TaskAndTime;
-      taskDto: TasksDto;
-    }
-
-    function createTasksAndTimes(taskId: number): tasksMock {
-      const timeSpent: number = 100;
-      const taskAndTime: TaskAndTime = new TaskAndTime();
-
-      taskAndTime.taskId = taskId;
-      taskAndTime.timeSpent = timeSpent;
-
-      const taskDto: TasksDto = new TasksDto();
-      const timesDto: GetPaginatedTimesDto = new GetPaginatedTimesDto();
-
-      timesDto.totalTimeSpent = timeSpent;
-      taskDto.id = taskId;
-      taskDto.totalTimeSpent = timeSpent;
-      taskDto.times = [timesDto];
-
-      return { taskAndTime, taskDto };
-    }
-
-    it('Convert tasks and times to paginated response', () => {
-      const mockedTasks: tasksMock = createTasksAndTimes(1);
-      const mockedTasksTwo: tasksMock = createTasksAndTimes(2);
-      const allTasksAndTimes: Array<TaskAndTime> = new Array<TaskAndTime>();
-
-      allTasksAndTimes.push(mockedTasks.taskAndTime);
-      allTasksAndTimes.push(mockedTasksTwo.taskAndTime);
-
+  describe('fromTasksToGetPaginatedTasksResponse tests', () => {
+    it('Convert tasks to paginated response', () => {
+      const timeSpentPerEntry: number = 100;
       const page: number = 1;
-      const userNumberOfTasks: number = 2;
-      const expected: GetPaginatedTaskResponseDto = new GetPaginatedTaskResponseDto();
-      const allTasksDtos: Array<TasksDto> = [mockedTasks.taskDto, mockedTasksTwo.taskDto];
+      const userTotalTasks: number = 10;
+      const tasks: Array<Task> = new Array<Task>();
+      const task: Task = new Task();
+      const taskTime: TaskTime = new TaskTime();
 
-      expected.isLastPage = true;
-      expected.page = 1;
-      expected.tasks = allTasksDtos;
+      taskTime.initiatedAt = '2024-02-26 10:30:18';
+      taskTime.endedAt = '2024-02-26 12:00:00';
+      taskTime.timeSpent = timeSpentPerEntry;
 
-      const response: GetPaginatedTaskResponseDto =
-        taskMapper.formTasksAndTimesToPaginatedTasksResponse(
-          allTasksAndTimes,
-          page,
-          userNumberOfTasks,
-        );
+      task.times = [taskTime, taskTime];
 
-      expect(response).toEqual(expected);
-      expect(response.tasks.length).toBe(allTasksDtos.length);
+      tasks.push(task, task);
+
+      const result: GetPaginatedTaskResponseDto = taskMapper.fromTasksToGetPaginatedTasksResponse(
+        tasks,
+        page,
+        userTotalTasks,
+      );
+
+      expect(result.tasks).toHaveLength(tasks.length);
+      expect(result.page).toEqual(1);
+      expect(result.isLastPage).toBeFalsy();
     });
   });
 });

--- a/src/migrations/1709719097070-createTaskTimeTable.ts
+++ b/src/migrations/1709719097070-createTaskTimeTable.ts
@@ -12,7 +12,7 @@ export class createTaskTimeTable1709719097070 implements MigrationInterface {
             ended_at TIMESTAMP NOT NULL,
             time_spent MEDIUMINT UNSIGNED NOT NULL,
             CONSTRAINT primary_task_time_id PRIMARY KEY (id),
-            CONSTRAINT foreign_task_id FOREIGN KEY(id_task) REFERENCES task(id)
+            CONSTRAINT foreign_task_id FOREIGN KEY(id_task) REFERENCES task(id) ON DELETE CASCADE
         );
     `);
   }

--- a/src/modules/task.module.ts
+++ b/src/modules/task.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { TaskController } from '@controllers';
@@ -12,13 +12,14 @@ import { TaskTimeModule } from './taskTime.module';
 
 @Module({
   imports: [
+    forwardRef(() => TaskTimeModule),
     UserModule,
     AuthModule,
-    TaskTimeModule,
     TypeOrmModule.forFeature([Task]),
     JwtModule.register({}),
   ],
   controllers: [TaskController],
   providers: [TaskService, TaskMapper, TaskValidator],
+  exports: [TaskService],
 })
 export class TaskModule {}

--- a/src/modules/taskTime.module.ts
+++ b/src/modules/taskTime.module.ts
@@ -5,7 +5,7 @@ import { TaskTime } from '@entities';
 import { TaskTimeController } from '@controllers';
 import { TaskTimeMapper } from '@mappers';
 import { TaskTimeValidator } from '@validators';
-import { TaskTimeService } from '@services';
+import { TaskService, TaskTimeService } from '@services';
 import { UserModule } from './user.module';
 import { AuthModule } from './auth.module';
 import { TaskModule } from './task.module';

--- a/src/modules/taskTime.module.ts
+++ b/src/modules/taskTime.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TaskTime } from '@entities';
@@ -8,9 +8,16 @@ import { TaskTimeValidator } from '@validators';
 import { TaskTimeService } from '@services';
 import { UserModule } from './user.module';
 import { AuthModule } from './auth.module';
+import { TaskModule } from './task.module';
 
 @Module({
-  imports: [UserModule, AuthModule, TypeOrmModule.forFeature([TaskTime]), JwtModule.register({})],
+  imports: [
+    forwardRef(() => TaskModule),
+    UserModule,
+    AuthModule,
+    TypeOrmModule.forFeature([TaskTime]),
+    JwtModule.register({}),
+  ],
   controllers: [TaskTimeController],
   providers: [TaskTimeMapper, TaskTimeService, TaskTimeValidator],
   exports: [TaskTimeService],

--- a/src/services/task-time/taskTime.service.test.ts
+++ b/src/services/task-time/taskTime.service.test.ts
@@ -170,20 +170,6 @@ describe('TaskTime service tests', () => {
     });
   });
 
-  describe('deleteAllTaskTimeByTaskId tests', () => {
-    it('Delete task times by task id with success', async () => {
-      const taskId: number = 1;
-      const deleteResponse: DeleteResult = new DeleteResult();
-
-      jest.spyOn(taskTimeRepository, 'delete').mockResolvedValueOnce(deleteResponse);
-
-      await taskTimeService.deleteAllTaskTimeByTaskId(taskId);
-
-      expect(taskTimeRepository.delete).toHaveBeenCalledTimes(1);
-      expect(taskTimeRepository.delete).toHaveBeenCalledWith({ taskId });
-    });
-  });
-
   describe('findOneById tests', () => {
     it('Find task time with success', async () => {
       const taskTimeId: number = 1;

--- a/src/services/task-time/taskTime.service.test.ts
+++ b/src/services/task-time/taskTime.service.test.ts
@@ -4,9 +4,9 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { DeleteResult, Repository, UpdateResult } from 'typeorm';
 import { TaskTimeController } from '@controllers';
-import { TaskTime, User } from '@entities';
-import { AuthMapper, TaskTimeMapper, UserMapper } from '@mappers';
-import { TaskTimeValidator, UserValidator } from '@validators';
+import { Task, TaskTime, User } from '@entities';
+import { AuthMapper, TaskMapper, TaskTimeMapper, UserMapper } from '@mappers';
+import { TaskTimeValidator, TaskValidator, UserValidator } from '@validators';
 import {
   CreateTaskTimeRequestDto,
   CreateTaskTimeResponseDto,
@@ -19,6 +19,7 @@ import { DELETE_TASK_TIME_NOT_FOUND, UPDATE_TASK_TIME_MISSING_TASK_TIME } from '
 import { TaskTimeService } from './taskTime.service';
 import { UserService } from '../user/user.service';
 import { AuthService } from '../auth/auth.service';
+import { TaskService } from '../task/task.service';
 
 jest.mock('@utils', () => ({
   ...jest.requireActual('@utils'),
@@ -35,6 +36,9 @@ describe('TaskTime service tests', () => {
     const ref: TestingModule = await Test.createTestingModule({
       controllers: [TaskTimeController],
       providers: [
+        TaskService,
+        TaskValidator,
+        TaskMapper,
         TaskTimeMapper,
         TaskTimeService,
         TaskTimeValidator,
@@ -45,6 +49,10 @@ describe('TaskTime service tests', () => {
         AuthService,
         AuthMapper,
         JwtService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: { findOneBy: jest.fn() },
+        },
         {
           provide: getRepositoryToken(User),
           useValue: {},

--- a/src/services/task-time/taskTime.service.ts
+++ b/src/services/task-time/taskTime.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import {
@@ -18,10 +18,10 @@ import { TaskService } from '../task/task.service';
 @Injectable()
 export class TaskTimeService {
   constructor(
+    @Inject(forwardRef(() => TaskService)) private taskService: TaskService,
     @InjectRepository(TaskTime) private taskTimeRepository: Repository<TaskTime>,
     private taskTimeValidator: TaskTimeValidator,
     private taskTimeMapper: TaskTimeMapper,
-    private taskService: TaskService,
   ) {}
 
   async createTaskTime(request: CreateTaskTimeRequestDto): Promise<CreateTaskTimeResponseDto> {
@@ -71,10 +71,6 @@ export class TaskTimeService {
     if (!taskTime) throw new DeleteTaskTimeException(`${DELETE_TASK_TIME_NOT_FOUND}${taskTimeId}.`);
 
     await this.taskTimeRepository.delete({ id: taskTimeId });
-  }
-
-  async deleteAllTaskTimeByTaskId(taskId: number): Promise<void> {
-    await this.taskTimeRepository.delete({ taskId });
   }
 
   async findOneById(id: number): Promise<TaskTime> {

--- a/src/services/task/task.service.test.ts
+++ b/src/services/task/task.service.test.ts
@@ -15,11 +15,10 @@ import {
   CreateTaskTimeResponseDto,
   GetPaginatedTaskRequestDto,
   GetPaginatedTaskResponseDto,
-  TaskDto,
   UpdateTaskRequestDto,
   UpdateTaskResponseDto,
 } from '@dtos';
-import { TaskAndTime, TasksPagination, UpdateTask } from '@interfaces';
+import { TasksPagination, UpdateTask } from '@interfaces';
 import { DeleteTaskException, UpdateTaskException } from '@exceptions';
 import { DELETE_TASK_NOT_FOUND, UPDATE_TASK_EXCEPTION_TASK_NOT_FOUND } from '@constants';
 import { getTaskOffsetByPage } from '@utils';
@@ -63,7 +62,14 @@ describe('TaskService Tests', () => {
         },
         {
           provide: getRepositoryToken(Task),
-          useValue: { save: jest.fn(), findOneBy: jest.fn(), update: jest.fn(), delete: jest.fn() },
+          useValue: {
+            save: jest.fn(),
+            findOneBy: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+            find: jest.fn(),
+            count: jest.fn(),
+          },
         },
         {
           provide: getRepositoryToken(TaskTime),
@@ -178,17 +184,16 @@ describe('TaskService Tests', () => {
     it('Delete a task and its task times with success', async () => {
       const taskId: number = 1;
       const task: Task = new Task();
-      const deleteResponse: DeleteResult = new DeleteResult();
 
       jest.spyOn(taskValidator, 'validateDeleteTask').mockImplementationOnce(() => {});
       jest.spyOn(taskService, 'findOneById').mockResolvedValueOnce(task);
-      jest.spyOn(taskRepository, 'delete').mockResolvedValueOnce(deleteResponse);
+      jest.spyOn(taskRepository, 'remove').mockResolvedValueOnce(task);
 
       await taskService.deleteTask(taskId);
 
       expect(taskValidator.validateDeleteTask).toHaveBeenCalledWith(taskId);
       expect(taskService.findOneById).toHaveBeenCalledWith(taskId);
-      expect(taskRepository.delete).toHaveBeenCalledWith({ id: taskId });
+      expect(taskRepository.remove).toHaveBeenCalledWith(task);
     });
     it('Delete a task without finded task throw error', async () => {
       const taskId: number = 2;
@@ -258,30 +263,32 @@ describe('TaskService Tests', () => {
 
   describe('getPaginatedTasks tests', () => {
     it('Get paginated user tasks with success', async () => {
-      // const request: GetPaginatedTaskRequestDto = new GetPaginatedTaskRequestDto();
-      // request.page = 1;
-      // request.userId = 15;
-      // const userNumberOfTasks: number = 10;
-      // const taskAndTimes: Array<TaskAndTime> = new Array<TaskAndTime>();
-      // const response: GetPaginatedTaskResponseDto = new GetPaginatedTaskResponseDto();
-      // const tasks: TaskDto = new TaskDto();
-      // const responseTasks: Array<TaskDto> = [tasks];
-      // response.isLastPage = false;
-      // response.page = request.page;
-      // response.tasks = responseTasks;
-      // jest
-      //   .spyOn(taskService, 'getTasksAndTaskTimesByUserAndPage')
-      //   .mockResolvedValueOnce(taskAndTimes);
-      // jest.spyOn(taskService, 'countTasksByUserId').mockResolvedValueOnce(userNumberOfTasks);
-      // jest
-      //   .spyOn(taskMapper, 'formTasksAndTimesToPaginatedTasksResponse')
-      //   .mockImplementationOnce(() => response);
-      // const result: void = await taskService.getPaginatedTasks(request);
-      // expect(result).toBe(response);
-      // expect(getTaskOffsetByPage).toHaveBeenCalled();
-      // expect(taskService.getTasksAndTaskTimesByUserAndPage).toHaveBeenCalled();
-      // expect(taskService.countTasksByUserId).toHaveBeenCalled();
-      // expect(taskMapper.formTasksAndTimesToPaginatedTasksResponse).toHaveBeenCalled();
+      const request: GetPaginatedTaskRequestDto = new GetPaginatedTaskRequestDto();
+
+      request.page = 1;
+      request.userId = 15;
+
+      const userNumberOfTasks: number = 10;
+      const tasks: Array<Task> = new Array<Task>();
+      const response: GetPaginatedTaskResponseDto = new GetPaginatedTaskResponseDto();
+
+      jest.spyOn(taskService, 'countTasksByUserId').mockResolvedValueOnce(userNumberOfTasks);
+      jest.spyOn(taskService, 'getTasksAndTaskTimesByUserAndPage').mockResolvedValueOnce(tasks);
+      jest
+        .spyOn(taskMapper, 'fromTasksToGetPaginatedTasksResponse')
+        .mockImplementationOnce(() => response);
+
+      const result: GetPaginatedTaskResponseDto = await taskService.getPaginatedTasks(request);
+
+      expect(result).toEqual(response);
+      expect(taskService.countTasksByUserId).toHaveBeenCalledWith(request.userId);
+      expect(taskService.getTasksAndTaskTimesByUserAndPage).toHaveBeenCalled();
+      expect(taskMapper.fromTasksToGetPaginatedTasksResponse).toHaveBeenCalledWith(
+        tasks,
+        request.page,
+        userNumberOfTasks,
+      );
+      expect(getTaskOffsetByPage).toHaveBeenCalledWith(request.page);
     });
   });
 });

--- a/src/services/task/task.service.test.ts
+++ b/src/services/task/task.service.test.ts
@@ -182,14 +182,12 @@ describe('TaskService Tests', () => {
 
       jest.spyOn(taskValidator, 'validateDeleteTask').mockImplementationOnce(() => {});
       jest.spyOn(taskService, 'findOneById').mockResolvedValueOnce(task);
-      jest.spyOn(taskTimeService, 'deleteAllTaskTimeByTaskId').mockImplementation(async () => {});
       jest.spyOn(taskRepository, 'delete').mockResolvedValueOnce(deleteResponse);
 
       await taskService.deleteTask(taskId);
 
       expect(taskValidator.validateDeleteTask).toHaveBeenCalledWith(taskId);
       expect(taskService.findOneById).toHaveBeenCalledWith(taskId);
-      expect(taskTimeService.deleteAllTaskTimeByTaskId).toHaveBeenCalledWith(taskId);
       expect(taskRepository.delete).toHaveBeenCalledWith({ id: taskId });
     });
     it('Delete a task without finded task throw error', async () => {

--- a/src/services/task/task.service.test.ts
+++ b/src/services/task/task.service.test.ts
@@ -15,7 +15,7 @@ import {
   CreateTaskTimeResponseDto,
   GetPaginatedTaskRequestDto,
   GetPaginatedTaskResponseDto,
-  TasksDto,
+  TaskDto,
   UpdateTaskRequestDto,
   UpdateTaskResponseDto,
 } from '@dtos';
@@ -258,36 +258,30 @@ describe('TaskService Tests', () => {
 
   describe('getPaginatedTasks tests', () => {
     it('Get paginated user tasks with success', async () => {
-      const request: GetPaginatedTaskRequestDto = new GetPaginatedTaskRequestDto();
-
-      request.page = 1;
-      request.userId = 15;
-
-      const userNumberOfTasks: number = 10;
-      const taskAndTimes: Array<TaskAndTime> = new Array<TaskAndTime>();
-      const response: GetPaginatedTaskResponseDto = new GetPaginatedTaskResponseDto();
-      const tasks: TasksDto = new TasksDto();
-      const responseTasks: Array<TasksDto> = [tasks];
-
-      response.isLastPage = false;
-      response.page = request.page;
-      response.tasks = responseTasks;
-
-      jest
-        .spyOn(taskService, 'getTasksAndTaskTimesByUserAndPage')
-        .mockResolvedValueOnce(taskAndTimes);
-      jest.spyOn(taskService, 'countTasksByUserId').mockResolvedValueOnce(userNumberOfTasks);
-      jest
-        .spyOn(taskMapper, 'formTasksAndTimesToPaginatedTasksResponse')
-        .mockImplementationOnce(() => response);
-
-      const result: GetPaginatedTaskResponseDto = await taskService.getPaginatedTasks(request);
-
-      expect(result).toBe(response);
-      expect(getTaskOffsetByPage).toHaveBeenCalled();
-      expect(taskService.getTasksAndTaskTimesByUserAndPage).toHaveBeenCalled();
-      expect(taskService.countTasksByUserId).toHaveBeenCalled();
-      expect(taskMapper.formTasksAndTimesToPaginatedTasksResponse).toHaveBeenCalled();
+      // const request: GetPaginatedTaskRequestDto = new GetPaginatedTaskRequestDto();
+      // request.page = 1;
+      // request.userId = 15;
+      // const userNumberOfTasks: number = 10;
+      // const taskAndTimes: Array<TaskAndTime> = new Array<TaskAndTime>();
+      // const response: GetPaginatedTaskResponseDto = new GetPaginatedTaskResponseDto();
+      // const tasks: TaskDto = new TaskDto();
+      // const responseTasks: Array<TaskDto> = [tasks];
+      // response.isLastPage = false;
+      // response.page = request.page;
+      // response.tasks = responseTasks;
+      // jest
+      //   .spyOn(taskService, 'getTasksAndTaskTimesByUserAndPage')
+      //   .mockResolvedValueOnce(taskAndTimes);
+      // jest.spyOn(taskService, 'countTasksByUserId').mockResolvedValueOnce(userNumberOfTasks);
+      // jest
+      //   .spyOn(taskMapper, 'formTasksAndTimesToPaginatedTasksResponse')
+      //   .mockImplementationOnce(() => response);
+      // const result: void = await taskService.getPaginatedTasks(request);
+      // expect(result).toBe(response);
+      // expect(getTaskOffsetByPage).toHaveBeenCalled();
+      // expect(taskService.getTasksAndTaskTimesByUserAndPage).toHaveBeenCalled();
+      // expect(taskService.countTasksByUserId).toHaveBeenCalled();
+      // expect(taskMapper.formTasksAndTimesToPaginatedTasksResponse).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Task, TaskTime } from '@entities';
@@ -27,7 +27,7 @@ export class TaskService {
     @InjectRepository(Task) private taskRepository: Repository<Task>,
     private taskValidator: TaskValidator,
     private taskMapper: TaskMapper,
-    private taskTimeService: TaskTimeService,
+    @Inject(forwardRef(() => TaskTimeService)) private taskTimeService: TaskTimeService,
   ) {}
 
   async create(
@@ -51,27 +51,6 @@ export class TaskService {
     return response;
   }
 
-  // async create(
-  //   user: AuthLoginResponseDto,
-  //   request: CreateTaskRequestDto,
-  // ): Promise<CreateTaskResponseDto> {
-  //   this.taskValidator.validateCreateTaskRequest(request);
-
-  //   const newTask: Task = this.taskMapper.fromCreateRequestToTask(user.id, request);
-  //   const entityResponse: Task = await this.taskRepository.save(newTask);
-  //   const taskTimeRequest: CreateTaskTimeRequestDto =
-  //     this.taskMapper.fromCreateRequestToCreateTaskTimeRequest(request, entityResponse.id);
-  //   const taskTime: CreateTaskTimeResponseDto = await this.taskTimeService.createTaskTime(
-  //     taskTimeRequest,
-  //   );
-  //   const response: CreateTaskResponseDto = this.taskMapper.fromTaskAndTaskTimeToCreateTaskResponse(
-  //     entityResponse,
-  //     taskTime,
-  //   );
-
-  //   return response;
-  // }
-
   async update(taskId: number, request: UpdateTaskRequestDto): Promise<UpdateTaskResponseDto> {
     this.taskValidator.validateUpdateTaskRequest(taskId);
 
@@ -93,9 +72,8 @@ export class TaskService {
     const task: Task = await this.findOneById(taskId);
 
     if (!task) throw new DeleteTaskException(DELETE_TASK_NOT_FOUND);
-
-    await this.taskTimeService.deleteAllTaskTimeByTaskId(taskId);
-    await this.taskRepository.delete({ id: taskId });
+    console.log(task);
+    await this.taskRepository.remove(task);
   }
 
   async getPaginatedTasks(

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Task } from '@entities';
+import { Task, TaskTime } from '@entities';
 import {
   AuthLoginResponseDto,
   CreateTaskRequestDto,
@@ -50,6 +50,27 @@ export class TaskService {
 
     return response;
   }
+
+  // async create(
+  //   user: AuthLoginResponseDto,
+  //   request: CreateTaskRequestDto,
+  // ): Promise<CreateTaskResponseDto> {
+  //   this.taskValidator.validateCreateTaskRequest(request);
+
+  //   const newTask: Task = this.taskMapper.fromCreateRequestToTask(user.id, request);
+  //   const entityResponse: Task = await this.taskRepository.save(newTask);
+  //   const taskTimeRequest: CreateTaskTimeRequestDto =
+  //     this.taskMapper.fromCreateRequestToCreateTaskTimeRequest(request, entityResponse.id);
+  //   const taskTime: CreateTaskTimeResponseDto = await this.taskTimeService.createTaskTime(
+  //     taskTimeRequest,
+  //   );
+  //   const response: CreateTaskResponseDto = this.taskMapper.fromTaskAndTaskTimeToCreateTaskResponse(
+  //     entityResponse,
+  //     taskTime,
+  //   );
+
+  //   return response;
+  // }
 
   async update(taskId: number, request: UpdateTaskRequestDto): Promise<UpdateTaskResponseDto> {
     this.taskValidator.validateUpdateTaskRequest(taskId);


### PR DESCRIPTION
## Descrição:

Ajustar para que as entidades utilizem as relações do typeOrm.

## Steps:

- Alterado para que tarefa e entrada de tempo utilizem as relações do typeorm.
- Alterado os metodos de save, delete e update de tarefa.
- Alterado o metodo de create da entrada de tempo.
- Alterado o metodo de busca de tarefas paginado.
- Ajustado os testes destes metodos para ficarem de acordo.

## Observações:

Este PR tem como objetivo facilitar a busca das tarefas com a utilização do typeOrm e as anotações de relação nas entidades.
