### PR TITLE
Remover o id do usuário da request de busca de tarefas paginado

### DIFF
--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -60,9 +60,10 @@ export class TaskController {
   @HttpCode(HttpStatus.OK)
   @Get('paginated')
   async getTaskPaginated(
+    @RequestUser() user: AuthLoginResponseDto,
     @Query() request: GetPaginatedTaskRequestDto,
   ): Promise<GetPaginatedTaskResponseDto> {
-    return await this.taskService.getPaginatedTasks(request);
+    return await this.taskService.getPaginatedTasks(request, user);
   }
 
   @UseGuards(UserJwtAuthGuard)

--- a/src/dto/task/get-paginated/request.dto.ts
+++ b/src/dto/task/get-paginated/request.dto.ts
@@ -1,4 +1,3 @@
 export class GetPaginatedTaskRequestDto {
   page: number;
-  userId: number;
 }

--- a/src/services/task/task.service.test.ts
+++ b/src/services/task/task.service.test.ts
@@ -268,10 +268,12 @@ describe('TaskService Tests', () => {
 
   describe('getPaginatedTasks tests', () => {
     it('Get paginated user tasks with success', async () => {
+      const user: AuthLoginResponseDto = new AuthLoginResponseDto();
+      user.id = 1;
+
       const request: GetPaginatedTaskRequestDto = new GetPaginatedTaskRequestDto();
 
       request.page = 1;
-      request.userId = 15;
 
       const userNumberOfTasks: number = 10;
       const tasks: Array<Task> = new Array<Task>();
@@ -283,10 +285,13 @@ describe('TaskService Tests', () => {
         .spyOn(taskMapper, 'fromTasksToGetPaginatedTasksResponse')
         .mockImplementationOnce(() => response);
 
-      const result: GetPaginatedTaskResponseDto = await taskService.getPaginatedTasks(request);
+      const result: GetPaginatedTaskResponseDto = await taskService.getPaginatedTasks(
+        request,
+        user,
+      );
 
       expect(result).toEqual(response);
-      expect(taskService.countTasksByUserId).toHaveBeenCalledWith(request.userId);
+      expect(taskService.countTasksByUserId).toHaveBeenCalledWith(user.id);
       expect(taskService.getTasksAndTaskTimesByUserAndPage).toHaveBeenCalled();
       expect(taskMapper.fromTasksToGetPaginatedTasksResponse).toHaveBeenCalledWith(
         tasks,

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -84,13 +84,15 @@ export class TaskService {
 
   async getPaginatedTasks(
     request: GetPaginatedTaskRequestDto,
+    user: AuthLoginResponseDto,
   ): Promise<GetPaginatedTaskResponseDto> {
+    console.log('userId', user.id);
     const pagination: TasksPagination = getTaskOffsetByPage(request.page);
     const taskAndTimes: Array<Task> = await this.getTasksAndTaskTimesByUserAndPage(
-      request.userId,
+      user.id,
       pagination,
     );
-    const userNumberOfTasks: number = await this.countTasksByUserId(request.userId);
+    const userNumberOfTasks: number = await this.countTasksByUserId(user.id);
     const response: GetPaginatedTaskResponseDto =
       this.taskMapper.fromTasksToGetPaginatedTasksResponse(
         taskAndTimes,
@@ -133,6 +135,7 @@ export class TaskService {
     userId: number,
     pagination: TasksPagination,
   ): Promise<Array<Task>> {
+    console.log('userId', userId);
     return await this.taskRepository.find({
       relations: {
         times: true,

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -86,7 +86,6 @@ export class TaskService {
     request: GetPaginatedTaskRequestDto,
     user: AuthLoginResponseDto,
   ): Promise<GetPaginatedTaskResponseDto> {
-    console.log('userId', user.id);
     const pagination: TasksPagination = getTaskOffsetByPage(request.page);
     const taskAndTimes: Array<Task> = await this.getTasksAndTaskTimesByUserAndPage(
       user.id,
@@ -135,7 +134,6 @@ export class TaskService {
     userId: number,
     pagination: TasksPagination,
   ): Promise<Array<Task>> {
-    console.log('userId', userId);
     return await this.taskRepository.find({
       relations: {
         times: true,


### PR DESCRIPTION
## Descrição:

Utilizar o usuário logado para a busca das tarefas paginadas.

## Steps:

- Removido o id do dto de request.
- Adicionado o usuário logado do passport.

