### PR TITLE
Adicionar o id da tarefa na criação de um tempo

### DIFF
--- a/src/constants/auth/auth.constant.ts
+++ b/src/constants/auth/auth.constant.ts
@@ -1,6 +1,6 @@
 export const BEARER_TOKEN_TYPE = 'Bearer';
 
-export const ACCESS_TOKEN_EXPIRATION_TIME = '15s';
+export const ACCESS_TOKEN_EXPIRATION_TIME = '1h';
 
 export const REFRESH_TOKEN_EXPIRATION_TIME = '1h';
 

--- a/src/dto/task-time/create/response.dto.ts
+++ b/src/dto/task-time/create/response.dto.ts
@@ -5,4 +5,5 @@ export class CreateTaskTimeResponseDto {
   endedAt: string;
   taskId: number;
   timeSpent: number;
+  id: number;
 }

--- a/src/dto/task/create/times.dto.ts
+++ b/src/dto/task/create/times.dto.ts
@@ -4,4 +4,5 @@ export class TimesDto {
   initiatedAt: string;
   endedAt: string;
   timeSpent: number;
+  id: number;
 }

--- a/src/mappers/task-time/taskTime.mapper.test.ts
+++ b/src/mappers/task-time/taskTime.mapper.test.ts
@@ -51,16 +51,30 @@ describe('TaskTime mapper tests', () => {
 
   describe('fromTaskTimeToCreateTaskTimeResponse tests', () => {
     it('Converts task time to create task time response', () => {
+      const task: Task = new Task();
       const taskTime: TaskTime = new TaskTime();
+
+      task.id = 1;
 
       taskTime.timeSpent = 1234;
       taskTime.initiatedAt = '2024-02-26 10:30:18';
       taskTime.endedAt = '2024-02-26 12:00:00';
+      taskTime.task = task;
+
+      const expected: CreateTaskTimeResponseDto = {
+        createdAt: taskTime.createdAt,
+        endedAt: taskTime.endedAt,
+        id: taskTime.id,
+        initiatedAt: taskTime.initiatedAt,
+        taskId: taskTime.task.id,
+        timeSpent: taskTime.timeSpent,
+        updatedAt: taskTime.updatedAt,
+      };
 
       const result: CreateTaskTimeResponseDto =
         taskTimeMapper.fromTaskTimeToCreateTaskTimeResponse(taskTime);
 
-      expect(result).toEqual(taskTime);
+      expect(result).toEqual(expected);
     });
   });
 

--- a/src/mappers/task-time/taskTime.mapper.ts
+++ b/src/mappers/task-time/taskTime.mapper.ts
@@ -38,6 +38,8 @@ export class TaskTimeMapper {
     response.initiatedAt = taskTime.initiatedAt;
     response.updatedAt = taskTime.updatedAt;
     response.timeSpent = taskTime.timeSpent;
+    response.id = taskTime.id;
+    response.taskId = taskTime.task.id;
 
     return response;
   }

--- a/src/mappers/task/task.mapper.ts
+++ b/src/mappers/task/task.mapper.ts
@@ -48,6 +48,7 @@ export class TaskMapper {
     times.initiatedAt = taskTime.initiatedAt;
     times.updatedAt = taskTime.updatedAt;
     times.timeSpent = taskTime.timeSpent;
+    times.id = taskTime.id;
 
     response.times = new Array(times);
 


### PR DESCRIPTION
## Descrição:

Adicionar o id da tarefa no retorno da criação de um tempo de tarefa.

## Steps:

- Adicionado o id da tarefa nos dto's necessários.
- Alterado o mapper para levar em conta o id da tarefa.
